### PR TITLE
Make TokenManager ETS registry init idempotent

### DIFF
--- a/lib/auth0/common/management/token_manager.ex
+++ b/lib/auth0/common/management/token_manager.ex
@@ -8,8 +8,14 @@ defmodule Auth0.Common.Management.TokenManager do
     @type expiration :: integer
     @spec init() :: :ok
     def init() do
-      _ = :ets.new(@registry, [:set, :protected, :named_table])
-      :ok
+      case :ets.whereis(@registry) do
+        :undefined ->
+          _ = :ets.new(@registry, [:set, :protected, :named_table])
+          :ok
+
+        _tid ->
+          :ok
+      end
     end
 
     @spec get(key) :: {token, expiration} | nil

--- a/lib/auth0/common/management/token_manager.ex
+++ b/lib/auth0/common/management/token_manager.ex
@@ -10,12 +10,27 @@ defmodule Auth0.Common.Management.TokenManager do
     def init() do
       case :ets.whereis(@registry) do
         :undefined ->
-          _ = :ets.new(@registry, [:set, :protected, :named_table])
-          :ok
+          create_registry()
 
         _tid ->
           :ok
       end
+    end
+
+    # The table is :public because it is created lazily by whichever caller
+    # first misses the cache, and every other caller process must still be able
+    # to write to it.
+    defp create_registry() do
+      _ = :ets.new(@registry, [:set, :public, :named_table])
+      :ok
+    rescue
+      error in ArgumentError ->
+        # Another process created the table between the whereis/1 check above
+        # and the :ets.new/2 call. That is the outcome we wanted anyway.
+        case :ets.whereis(@registry) do
+          :undefined -> reraise(error, __STACKTRACE__)
+          _tid -> :ok
+        end
     end
 
     @spec get(key) :: {token, expiration} | nil

--- a/test/auth0/common/management/http_test.exs
+++ b/test/auth0/common/management/http_test.exs
@@ -1,7 +1,6 @@
 defmodule Auth0.Common.Management.HttpTest do
   use ExUnit.Case
   alias Auth0.Common.Management.Http
-  alias Auth0.Common.Management.TokenManager
   alias Auth0.Config
 
   setup do
@@ -66,21 +65,4 @@ defmodule Auth0.Common.Management.HttpTest do
       assert {:ok, %HTTPoison.Response{status_code: 204}} = Http.raw_request(:delete, "/test", %{}, nil, config(bypass))
     end
   end
-
-  describe "TokenManager.Store.init/0" do
-    test "is idempotent when the registry table already exists" do
-      :ets.whereis(:tokens_registry)
-      |> maybe_delete_registry()
-
-      assert :ok = TokenManager.Store.init()
-      assert :ok = TokenManager.Store.init()
-      assert :ets.whereis(:tokens_registry) != :undefined
-
-      :ets.whereis(:tokens_registry)
-      |> maybe_delete_registry()
-    end
-  end
-
-  defp maybe_delete_registry(:undefined), do: :ok
-  defp maybe_delete_registry(table), do: :ets.delete(table)
 end

--- a/test/auth0/common/management/http_test.exs
+++ b/test/auth0/common/management/http_test.exs
@@ -1,6 +1,7 @@
 defmodule Auth0.Common.Management.HttpTest do
   use ExUnit.Case
   alias Auth0.Common.Management.Http
+  alias Auth0.Common.Management.TokenManager
   alias Auth0.Config
 
   setup do
@@ -65,4 +66,21 @@ defmodule Auth0.Common.Management.HttpTest do
       assert {:ok, %HTTPoison.Response{status_code: 204}} = Http.raw_request(:delete, "/test", %{}, nil, config(bypass))
     end
   end
+
+  describe "TokenManager.Store.init/0" do
+    test "is idempotent when the registry table already exists" do
+      :ets.whereis(:tokens_registry)
+      |> maybe_delete_registry()
+
+      assert :ok = TokenManager.Store.init()
+      assert :ok = TokenManager.Store.init()
+      assert :ets.whereis(:tokens_registry) != :undefined
+
+      :ets.whereis(:tokens_registry)
+      |> maybe_delete_registry()
+    end
+  end
+
+  defp maybe_delete_registry(:undefined), do: :ok
+  defp maybe_delete_registry(table), do: :ets.delete(table)
 end

--- a/test/auth0/common/management/token_manager_test.exs
+++ b/test/auth0/common/management/token_manager_test.exs
@@ -1,0 +1,74 @@
+defmodule Auth0.Common.Management.TokenManagerTest do
+  use ExUnit.Case
+
+  alias Auth0.Common.Management.TokenManager.Store
+
+  @registry :tokens_registry
+
+  setup do
+    delete_registry()
+    on_exit(&delete_registry/0)
+    :ok
+  end
+
+  describe "init/0" do
+    test "is idempotent when the registry table already exists" do
+      assert :ok = Store.init()
+      assert :ok = Store.init()
+      assert :ets.whereis(@registry) != :undefined
+    end
+
+    test "does not raise when another live process already owns the table" do
+      owner = spawn_registry_owner()
+
+      assert :ok = Store.init()
+      assert :ets.info(@registry, :owner) == owner
+    end
+  end
+
+  describe "put/2 and get/1" do
+    test "create the table on first use" do
+      assert :ets.whereis(@registry) == :undefined
+
+      assert :ok = Store.put("client-id", {"token", 123})
+      assert {"token", 123} = Store.get("client-id")
+    end
+
+    test "succeed from a process that does not own the table" do
+      owner = spawn_registry_owner()
+      assert :ets.info(@registry, :owner) == owner
+
+      assert :ok = Store.put("client-id", {"token", 123})
+      assert {"token", 123} = Store.get("client-id")
+    end
+  end
+
+  # Creates the registry from a separate, still-running process so the test
+  # process is a non-owner for the duration of the test. Linked, so the table
+  # goes away with the test process.
+  defp spawn_registry_owner() do
+    test = self()
+
+    owner =
+      spawn_link(fn ->
+        :ok = Store.init()
+        send(test, :registry_created)
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive :registry_created
+    owner
+  end
+
+  defp delete_registry() do
+    case :ets.whereis(@registry) do
+      :undefined -> :ok
+      table -> :ets.delete(table)
+    end
+
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary

- make Auth0.Common.Management.TokenManager.Store.init/0 safe when the named ETS table already exists
- add regression coverage proving repeated initialization does not raise

## Problem

TokenManager.Store.init/0 currently creates the named ETS table :tokens_registry unconditionally. If initialization is retried after the table already exists, it can raise:

```
    ArgumentError: table name already exists
```

This can bubble up through management token acquisition and break normal management API calls.